### PR TITLE
Crs 1522 gps make all stamped messages use system time rather than gps time

### DIFF
--- a/ublox_gps/include/ublox_gps/node.h
+++ b/ublox_gps/include/ublox_gps/node.h
@@ -789,26 +789,29 @@ class UbloxFirmware7Plus : public UbloxFirmware {
 
     sensor_msgs::NavSatFix fix;
     fix.header.frame_id = frame_id;
-    // set the timestamp
-    uint8_t valid_time = m.VALID_DATE | m.VALID_TIME | m.VALID_FULLY_RESOLVED;
-    if (((m.valid & valid_time) == valid_time) &&
-        (m.flags2 & m.FLAGS2_CONFIRMED_AVAILABLE)) {
-      // Use NavPVT timestamp since it is valid
-      // The time in nanoseconds from the NavPVT message can be between -1e9 and 1e9
-      //  The ros time uses only unsigned values, so a negative nano seconds must be
-      //  converted to a positive value
-      if (m.nano < 0) {
-        fix.header.stamp.sec = toUtcSeconds(m) - 1;
-        fix.header.stamp.nsec = (uint32_t)(m.nano + 1e9);
-      }
-      else {
-        fix.header.stamp.sec = toUtcSeconds(m);
-        fix.header.stamp.nsec = (uint32_t)(m.nano);
-      }
-    } else {
-      // Use ROS time since NavPVT timestamp is not valid
-      fix.header.stamp = ros::Time::now();
-    }
+
+    // Use the stamp from the read message
+    fix.header.stamp = m.header.stamp;
+
+    // uint8_t valid_time = m.VALID_DATE | m.VALID_TIME | m.VALID_FULLY_RESOLVED;
+    // if (((m.valid & valid_time) == valid_time) &&
+    //     (m.flags2 & m.FLAGS2_CONFIRMED_AVAILABLE)) {
+    //   // Use NavPVT timestamp since it is valid
+    //   // The time in nanoseconds from the NavPVT message can be between -1e9 and 1e9
+    //   //  The ros time uses only unsigned values, so a negative nano seconds must be
+    //   //  converted to a positive value
+    //   if (m.nano < 0) {
+    //     fix.header.stamp.sec = toUtcSeconds(m) - 1;
+    //     fix.header.stamp.nsec = (uint32_t)(m.nano + 1e9);
+    //   }
+    //   else {
+    //     fix.header.stamp.sec = toUtcSeconds(m);
+    //     fix.header.stamp.nsec = (uint32_t)(m.nano);
+    //   }
+    // } else {
+    //   // Use ROS time since NavPVT timestamp is not valid
+    //   fix.header.stamp = ros::Time::now();
+    // }
     // Set the LLA
     fix.latitude = m.lat * 1e-7; // to deg
     fix.longitude = m.lon * 1e-7; // to deg

--- a/ublox_msgs/include/ublox/serialization/ublox_msgs.h
+++ b/ublox_msgs/include/ublox/serialization/ublox_msgs.h
@@ -962,7 +962,31 @@ struct Serializer<ublox_msgs::NavPVT_<ContainerAllocator> > {
     stream.next(m.headVeh);
     stream.next(m.magDec);
     stream.next(m.magAcc);
+
+    // Only use system stamp, not GPS - CRS-1522
     m.header.stamp = ros::Time::now();
+
+    // uint8_t valid_time = m.VALID_DATE | m.VALID_TIME | m.VALID_FULLY_RESOLVED;
+    // if (((m.valid & valid_time) == valid_time) &&
+    //     (m.flags2 & m.FLAGS2_CONFIRMED_AVAILABLE)) {
+    //   // Use NavPVT timestamp since it is valid
+    //   // The time in nanoseconds from the NavPVT message can be between -1e9 and 1e9
+    //   //  The ros time uses only unsigned values, so a negative nano seconds must be
+    //   //  converted to a positive value
+    //   if (m.nano < 0) {
+    //     m.header.stamp.sec = toUtcSeconds(m) - 1;
+    //     m.header.stamp.nsec = (uint32_t)(m.nano + 1e9);
+    //   }
+    //   else {
+    //     m.header.stamp.sec = toUtcSeconds(m);
+    //     m.header.stamp.nsec = (uint32_t)(m.nano);
+    //   }
+    // } else {
+    //   // Use ROS time since NavPVT timestamp is not valid
+    //   ROS_WARN_THROTTLE("NavPVT timestamp not valid, using ROS time instead");
+    //   m.header.stamp = ros::Time::now();
+    // }
+
   }
 };
 

--- a/ublox_msgs/msg/NavPVT7.msg
+++ b/ublox_msgs/msg/NavPVT7.msg
@@ -86,3 +86,6 @@ uint32 headAcc          # Heading Accuracy Estimate (both motion & vehicle)
 
 uint16 pDOP             # Position DOP [1 / 0.01]
 uint8[6] reserved1      # Reserved
+
+Header header           # Header injected by ROS Node - This data is not present 
+                        # in the serialised message from the GPS


### PR DESCRIPTION
Changes based off CRS-1522:

- Force use of current ROS timestamp in NavPVT messages instead of trying to derive satellite time
- Add header to the NavPVT7 message definition